### PR TITLE
JAVA-2782: Native substitution fixes + driver (re)upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <datastax-java-driver.version>4.5.0</datastax-java-driver.version>
+    <datastax-java-driver.version>4.6.1</datastax-java-driver.version>
     <!--suppress UnresolvedMavenProperty -->
     <graalvmHome>${env.GRAALVM_HOME}</graalvmHome>
   </properties>

--- a/runtime/src/main/java/com/datastax/oss/quarkus/runtime/graal/NativeSubstitutions.java
+++ b/runtime/src/main/java/com/datastax/oss/quarkus/runtime/graal/NativeSubstitutions.java
@@ -15,20 +15,40 @@
  */
 package com.datastax.oss.quarkus.runtime.graal;
 
+import com.datastax.oss.driver.internal.core.os.CpuInfo;
 import com.datastax.oss.driver.internal.core.os.Native;
+import com.oracle.svm.core.annotate.KeepOriginal;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
 @TargetClass(Native.class)
+@Substitute
 final class NativeSubstitutions {
 
-  /**
-   * This method returns always false because jnr is not available.
-   *
-   * @return false denoting that {@link Native#getProcessId()} cannot be called.
-   */
+  @Substitute private static final CpuInfo.Cpu CPU = CpuInfo.determineCpu();
+
   @Substitute
   public static boolean isGetProcessIdAvailable() {
     return false;
+  }
+
+  @Substitute
+  public static int getProcessId() {
+    throw new RuntimeException("Native operations are not supported on this platform");
+  }
+
+  @Substitute
+  public static boolean isCurrentTimeMicrosAvailable() {
+    return false;
+  }
+
+  @Substitute
+  public static long currentTimeMicros() {
+    throw new RuntimeException("Native operations are not supported on this platform");
+  }
+
+  @KeepOriginal
+  public static String getCpu() {
+    return null;
   }
 }

--- a/runtime/src/main/java/com/datastax/oss/quarkus/runtime/graal/NativeSubstitutions.java
+++ b/runtime/src/main/java/com/datastax/oss/quarkus/runtime/graal/NativeSubstitutions.java
@@ -34,7 +34,7 @@ final class NativeSubstitutions {
 
   @Substitute
   public static int getProcessId() {
-    throw new RuntimeException("Native operations are not supported on this platform");
+    throw new IllegalStateException("Native operations are not supported on this platform");
   }
 
   @Substitute
@@ -44,7 +44,7 @@ final class NativeSubstitutions {
 
   @Substitute
   public static long currentTimeMicros() {
-    throw new RuntimeException("Native operations are not supported on this platform");
+    throw new IllegalStateException("Native operations are not supported on this platform");
   }
 
   @KeepOriginal


### PR DESCRIPTION
Fix for the native substitutions to address the recent failures to build native images without requiring a specific driver version.

This PR contains the native substitution from https://github.com/datastax/cassandra-quarkus/pull/14