### PR TITLE
Adds docker host to test resource

### DIFF
--- a/quickstart/src/test/resources/application.properties
+++ b/quickstart/src/test/resources/application.properties
@@ -16,6 +16,6 @@
 
 # Override contact points and inject the port of the Cassandra container
 # used for tests; see CassandraTestResource in the test-framework module.
-quarkus.cassandra.contact-points=127.0.0.1:${quarkus.cassandra.docker_port}
+quarkus.cassandra.contact-points=${quarkus.cassandra.docker_host}:${quarkus.cassandra.docker_port}
 quarkus.cassandra.local-datacenter=datacenter1
 fruit.dao.keyspace=k1

--- a/test-framework/src/main/java/com/datastax/oss/quarkus/test/CassandraTestResource.java
+++ b/test-framework/src/main/java/com/datastax/oss/quarkus/test/CassandraTestResource.java
@@ -17,7 +17,7 @@ package com.datastax.oss.quarkus.test;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import java.net.URL;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.CassandraContainer;
@@ -57,8 +57,13 @@ public class CassandraTestResource implements QuarkusTestResourceLifecycleManage
     cassandraContainer.start();
     String exposedPort =
         String.valueOf(cassandraContainer.getMappedPort(CassandraContainer.CQL_PORT));
-    LOGGER.infof("Started %s on port %s", cassandraContainer.getDockerImageName(), exposedPort);
-    return Collections.singletonMap("quarkus.cassandra.docker_port", exposedPort);
+    String exposedHost = cassandraContainer.getContainerIpAddress();
+    LOGGER.infof(
+        "Started %s on %s:%s", cassandraContainer.getDockerImageName(), exposedHost, exposedPort);
+    HashMap<String, String> result = new HashMap<>();
+    result.put("quarkus.cassandra.docker_host", exposedHost);
+    result.put("quarkus.cassandra.docker_port", exposedPort);
+    return result;
   }
 
   @Override


### PR DESCRIPTION
In some CI/CD pipeline system docker is not running on localhost. To avoid these problems I would like to add the application setting: quarkus.cassandra.docker_host