### PR TITLE
small-rye metrics should not be optional

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -63,7 +63,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-metrics</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>


### PR DESCRIPTION
2020-07-06 15:26:31,458 ERROR [io.qua.dep.dev.DevModeMain] (main) Failed to start Quarkus: java.lang.RuntimeException: java.lang.RuntimeException: Failed to start quarkus
    at io.quarkus.dev.appstate.ApplicationStateNotification.waitForApplicationStart(ApplicationStateNotification.java:51)
    at io.quarkus.runner.bootstrap.StartupActionImpl.runMainClass(StartupActionImpl.java:155)
    at io.quarkus.deployment.dev.IsolatedDevModeMain.firstStart(IsolatedDevModeMain.java:95)
    at io.quarkus.deployment.dev.IsolatedDevModeMain.accept(IsolatedDevModeMain.java:301)
    at io.quarkus.deployment.dev.IsolatedDevModeMain.accept(IsolatedDevModeMain.java:42)
    at io.quarkus.bootstrap.app.CuratedApplication.runInCl(CuratedApplication.java:131)
    at io.quarkus.bootstrap.app.CuratedApplication.runInAugmentClassLoader(CuratedApplication.java:84)
    at io.quarkus.deployment.dev.DevModeMain.start(DevModeMain.java:126)
    at io.quarkus.deployment.dev.DevModeMain.main(DevModeMain.java:56)
Caused by: java.lang.RuntimeException: Failed to start quarkus
    at io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:487)
    at io.quarkus.runtime.Application.start(Application.java:90)
    at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:90)
    at io.quarkus.runtime.Quarkus.run(Quarkus.java:61)
    at io.quarkus.runtime.Quarkus.run(Quarkus.java:38)
    at io.quarkus.runtime.Quarkus.run(Quarkus.java:106)
    at io.quarkus.runner.GeneratedMain.main(GeneratedMain.zig:29)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:564)
    at io.quarkus.runner.bootstrap.StartupActionImpl$3.run(StartupActionImpl.java:144)
    at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.lang.NoClassDefFoundError: org/eclipse/microprofile/metrics/MetricRegistry
    at java.base/java.lang.ClassLoader.defineClass1(Native Method)
    at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
    at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:372)
    at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:330)
    at com.datastax.oss.quarkus.runtime.internal.quarkus.CassandraClientRecorder.setNoopMetricRegistry(CassandraClientRecorder.java:61)
    at io.quarkus.deployment.steps.CassandraClientProcessor$configureRuntimeProperties415902352.deploy_0(CassandraClientProcessor$configureRuntimeProperties415902352.zig:175)
    at io.quarkus.deployment.steps.CassandraClientProcessor$configureRuntimeProperties415902352.deploy(CassandraClientProcessor$configureRuntimeProperties415902352.zig:36)
    at io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:354)
    ... 12 more
Caused by: java.lang.ClassNotFoundException: org.eclipse.microprofile.metrics.MetricRegistry
    at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:602)
    at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
    at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
    at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:378)
    at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:330)
    ... 20 more