### PR TITLE
Avoid implementing Multi and extend AbstractMulti instead

### DIFF
--- a/runtime/src/main/java/com/datastax/oss/quarkus/runtime/internal/reactive/DefaultMutinyGraphReactiveResultSet.java
+++ b/runtime/src/main/java/com/datastax/oss/quarkus/runtime/internal/reactive/DefaultMutinyGraphReactiveResultSet.java
@@ -21,24 +21,12 @@ import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.quarkus.runtime.api.reactive.MutinyGraphReactiveResultSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.groups.MultiBroadcast;
-import io.smallrye.mutiny.groups.MultiCollect;
-import io.smallrye.mutiny.groups.MultiConvert;
-import io.smallrye.mutiny.groups.MultiGroup;
-import io.smallrye.mutiny.groups.MultiOnCompletion;
-import io.smallrye.mutiny.groups.MultiOnEvent;
-import io.smallrye.mutiny.groups.MultiOnFailure;
-import io.smallrye.mutiny.groups.MultiOnItem;
-import io.smallrye.mutiny.groups.MultiOverflow;
-import io.smallrye.mutiny.groups.MultiSubscribe;
-import io.smallrye.mutiny.groups.MultiTransform;
-import java.util.concurrent.Executor;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import org.reactivestreams.Subscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
 
-public class DefaultMutinyGraphReactiveResultSet implements MutinyGraphReactiveResultSet {
+public class DefaultMutinyGraphReactiveResultSet extends AbstractMulti<ReactiveGraphNode>
+    implements MutinyGraphReactiveResultSet {
 
   private final Multi<ReactiveGraphNode> multi;
   private final Multi<ExecutionInfo> executionInfos;
@@ -57,98 +45,7 @@ public class DefaultMutinyGraphReactiveResultSet implements MutinyGraphReactiveR
     return executionInfos;
   }
 
-  @Override
-  public MultiSubscribe<ReactiveGraphNode> subscribe() {
-    return multi.subscribe();
-  }
-
-  @Override
-  public MultiOnItem<ReactiveGraphNode> onItem() {
-    return multi.onItem();
-  }
-
-  @Override
-  public <O> O then(Function<Multi<ReactiveGraphNode>, O> stage) {
-    return multi.then(stage);
-  }
-
-  @Override
-  public Uni<ReactiveGraphNode> toUni() {
-    return multi.toUni();
-  }
-
-  @Override
-  public MultiOnFailure<ReactiveGraphNode> onFailure() {
-    return multi.onFailure();
-  }
-
-  @Override
-  public MultiOnFailure<ReactiveGraphNode> onFailure(Predicate<? super Throwable> predicate) {
-    return multi.onFailure(predicate);
-  }
-
-  @Override
-  public MultiOnFailure<ReactiveGraphNode> onFailure(Class<? extends Throwable> aClass) {
-    return multi.onFailure(aClass);
-  }
-
-  @Override
-  public MultiOnEvent<ReactiveGraphNode> on() {
-    return multi.on();
-  }
-
-  @Override
-  public Multi<ReactiveGraphNode> cache() {
-    return multi.cache();
-  }
-
-  @Override
-  public MultiCollect<ReactiveGraphNode> collectItems() {
-    return multi.collectItems();
-  }
-
-  @Override
-  public MultiGroup<ReactiveGraphNode> groupItems() {
-    return multi.groupItems();
-  }
-
-  @Override
-  public Multi<ReactiveGraphNode> emitOn(Executor executor) {
-    return multi.emitOn(executor);
-  }
-
-  @Override
-  public Multi<ReactiveGraphNode> runSubscriptionOn(Executor executor) {
-    return multi.runSubscriptionOn(executor);
-  }
-
-  @Override
-  public MultiOnCompletion<ReactiveGraphNode> onCompletion() {
-    return multi.onCompletion();
-  }
-
-  @Override
-  public MultiTransform<ReactiveGraphNode> transform() {
-    return multi.transform();
-  }
-
-  @Override
-  public MultiOverflow<ReactiveGraphNode> onOverflow() {
-    return multi.onOverflow();
-  }
-
-  @Override
-  public MultiBroadcast<ReactiveGraphNode> broadcast() {
-    return multi.broadcast();
-  }
-
-  @Override
-  public MultiConvert<ReactiveGraphNode> convert() {
-    return multi.convert();
-  }
-
-  @Override
-  public void subscribe(Subscriber<? super ReactiveGraphNode> subscriber) {
-    multi.subscribe(subscriber);
+  public void subscribe(MultiSubscriber<? super ReactiveGraphNode> subscriber) {
+    multi.subscribe(Infrastructure.onMultiSubscription(multi, subscriber));
   }
 }

--- a/runtime/src/main/java/com/datastax/oss/quarkus/runtime/internal/reactive/DefaultMutinyMappedReactiveResultSet.java
+++ b/runtime/src/main/java/com/datastax/oss/quarkus/runtime/internal/reactive/DefaultMutinyMappedReactiveResultSet.java
@@ -21,24 +21,11 @@ import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.quarkus.runtime.api.reactive.mapper.MutinyMappedReactiveResultSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.groups.MultiBroadcast;
-import io.smallrye.mutiny.groups.MultiCollect;
-import io.smallrye.mutiny.groups.MultiConvert;
-import io.smallrye.mutiny.groups.MultiGroup;
-import io.smallrye.mutiny.groups.MultiOnCompletion;
-import io.smallrye.mutiny.groups.MultiOnEvent;
-import io.smallrye.mutiny.groups.MultiOnFailure;
-import io.smallrye.mutiny.groups.MultiOnItem;
-import io.smallrye.mutiny.groups.MultiOverflow;
-import io.smallrye.mutiny.groups.MultiSubscribe;
-import io.smallrye.mutiny.groups.MultiTransform;
-import java.util.concurrent.Executor;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import org.reactivestreams.Subscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
 
-public class DefaultMutinyMappedReactiveResultSet<EntityT>
+public class DefaultMutinyMappedReactiveResultSet<EntityT> extends AbstractMulti<EntityT>
     implements MutinyMappedReactiveResultSet<EntityT> {
   private final Multi<EntityT> multi;
   private final Multi<ExecutionInfo> executionInfos;
@@ -77,97 +64,7 @@ public class DefaultMutinyMappedReactiveResultSet<EntityT>
   }
 
   @Override
-  public MultiSubscribe<EntityT> subscribe() {
-    return multi.subscribe();
-  }
-
-  @Override
-  public MultiOnItem<EntityT> onItem() {
-    return multi.onItem();
-  }
-
-  @Override
-  public <O> O then(Function<Multi<EntityT>, O> stage) {
-    return multi.then(stage);
-  }
-
-  @Override
-  public Uni<EntityT> toUni() {
-    return multi.toUni();
-  }
-
-  @Override
-  public MultiOnFailure<EntityT> onFailure() {
-    return multi.onFailure();
-  }
-
-  @Override
-  public MultiOnFailure<EntityT> onFailure(Predicate<? super Throwable> predicate) {
-    return multi.onFailure(predicate);
-  }
-
-  @Override
-  public MultiOnFailure<EntityT> onFailure(Class<? extends Throwable> aClass) {
-    return multi.onFailure(aClass);
-  }
-
-  @Override
-  public MultiOnEvent<EntityT> on() {
-    return multi.on();
-  }
-
-  @Override
-  public Multi<EntityT> cache() {
-    return multi.cache();
-  }
-
-  @Override
-  public MultiCollect<EntityT> collectItems() {
-    return multi.collectItems();
-  }
-
-  @Override
-  public MultiGroup<EntityT> groupItems() {
-    return multi.groupItems();
-  }
-
-  @Override
-  public Multi<EntityT> emitOn(Executor executor) {
-    return multi.emitOn(executor);
-  }
-
-  @Override
-  public Multi<EntityT> runSubscriptionOn(Executor executor) {
-    return multi.runSubscriptionOn(executor);
-  }
-
-  @Override
-  public MultiOnCompletion<EntityT> onCompletion() {
-    return multi.onCompletion();
-  }
-
-  @Override
-  public MultiTransform<EntityT> transform() {
-    return multi.transform();
-  }
-
-  @Override
-  public MultiOverflow<EntityT> onOverflow() {
-    return multi.onOverflow();
-  }
-
-  @Override
-  public MultiBroadcast<EntityT> broadcast() {
-    return multi.broadcast();
-  }
-
-  @Override
-  public MultiConvert<EntityT> convert() {
-    return multi.convert();
-  }
-
-  @Override
-  public void subscribe(Subscriber<? super EntityT> subscriber) {
-    multi.subscribe(subscriber);
+  public void subscribe(MultiSubscriber<? super EntityT> subscriber) {
+    multi.subscribe(Infrastructure.onMultiSubscription(multi, subscriber));
   }
 }

--- a/runtime/src/main/java/com/datastax/oss/quarkus/runtime/internal/reactive/DefaultMutinyReactiveResultSet.java
+++ b/runtime/src/main/java/com/datastax/oss/quarkus/runtime/internal/reactive/DefaultMutinyReactiveResultSet.java
@@ -23,24 +23,11 @@ import com.datastax.oss.quarkus.runtime.api.reactive.MutinyContinuousReactiveRes
 import com.datastax.oss.quarkus.runtime.api.reactive.MutinyReactiveResultSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.groups.MultiBroadcast;
-import io.smallrye.mutiny.groups.MultiCollect;
-import io.smallrye.mutiny.groups.MultiConvert;
-import io.smallrye.mutiny.groups.MultiGroup;
-import io.smallrye.mutiny.groups.MultiOnCompletion;
-import io.smallrye.mutiny.groups.MultiOnEvent;
-import io.smallrye.mutiny.groups.MultiOnFailure;
-import io.smallrye.mutiny.groups.MultiOnItem;
-import io.smallrye.mutiny.groups.MultiOverflow;
-import io.smallrye.mutiny.groups.MultiSubscribe;
-import io.smallrye.mutiny.groups.MultiTransform;
-import java.util.concurrent.Executor;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import org.reactivestreams.Subscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
 
-public class DefaultMutinyReactiveResultSet
+public class DefaultMutinyReactiveResultSet extends AbstractMulti<ReactiveRow>
     implements MutinyReactiveResultSet, MutinyContinuousReactiveResultSet {
 
   private final Multi<ReactiveRow> multi;
@@ -80,97 +67,7 @@ public class DefaultMutinyReactiveResultSet
   }
 
   @Override
-  public MultiSubscribe<ReactiveRow> subscribe() {
-    return multi.subscribe();
-  }
-
-  @Override
-  public MultiOnItem<ReactiveRow> onItem() {
-    return multi.onItem();
-  }
-
-  @Override
-  public <O> O then(Function<Multi<ReactiveRow>, O> stage) {
-    return multi.then(stage);
-  }
-
-  @Override
-  public Uni<ReactiveRow> toUni() {
-    return multi.toUni();
-  }
-
-  @Override
-  public MultiOnFailure<ReactiveRow> onFailure() {
-    return multi.onFailure();
-  }
-
-  @Override
-  public MultiOnFailure<ReactiveRow> onFailure(Predicate<? super Throwable> predicate) {
-    return multi.onFailure(predicate);
-  }
-
-  @Override
-  public MultiOnFailure<ReactiveRow> onFailure(Class<? extends Throwable> aClass) {
-    return multi.onFailure(aClass);
-  }
-
-  @Override
-  public MultiOnEvent<ReactiveRow> on() {
-    return multi.on();
-  }
-
-  @Override
-  public Multi<ReactiveRow> cache() {
-    return multi.cache();
-  }
-
-  @Override
-  public MultiCollect<ReactiveRow> collectItems() {
-    return multi.collectItems();
-  }
-
-  @Override
-  public MultiGroup<ReactiveRow> groupItems() {
-    return multi.groupItems();
-  }
-
-  @Override
-  public Multi<ReactiveRow> emitOn(Executor executor) {
-    return multi.emitOn(executor);
-  }
-
-  @Override
-  public Multi<ReactiveRow> runSubscriptionOn(Executor executor) {
-    return multi.runSubscriptionOn(executor);
-  }
-
-  @Override
-  public MultiOnCompletion<ReactiveRow> onCompletion() {
-    return multi.onCompletion();
-  }
-
-  @Override
-  public MultiTransform<ReactiveRow> transform() {
-    return multi.transform();
-  }
-
-  @Override
-  public MultiOverflow<ReactiveRow> onOverflow() {
-    return multi.onOverflow();
-  }
-
-  @Override
-  public MultiBroadcast<ReactiveRow> broadcast() {
-    return multi.broadcast();
-  }
-
-  @Override
-  public MultiConvert<ReactiveRow> convert() {
-    return multi.convert();
-  }
-
-  @Override
-  public void subscribe(Subscriber<? super ReactiveRow> subscriber) {
-    multi.subscribe(subscriber);
+  public void subscribe(MultiSubscriber<? super ReactiveRow> subscriber) {
+    multi.subscribe(Infrastructure.onMultiSubscription(multi, subscriber));
   }
 }

--- a/runtime/src/main/java/com/datastax/oss/quarkus/runtime/internal/reactive/Wrappers.java
+++ b/runtime/src/main/java/com/datastax/oss/quarkus/runtime/internal/reactive/Wrappers.java
@@ -29,7 +29,7 @@ public class Wrappers {
     Multi<T> multi = Multi.createFrom().publisher(source);
     Context context = Vertx.currentContext();
     if (context != null) {
-      multi = multi.emitOn(new VertexContextExecutor(context));
+      multi = multi.emitOn(new VertxContextExecutor(context));
     }
     return multi;
   }
@@ -38,7 +38,7 @@ public class Wrappers {
     Context context = Vertx.currentContext();
     Uni<T> uni = Uni.createFrom().publisher(source);
     if (context != null) {
-      uni = uni.emitOn(new VertexContextExecutor(context));
+      uni = uni.emitOn(new VertxContextExecutor(context));
     }
     return uni;
   }
@@ -47,11 +47,11 @@ public class Wrappers {
     return Uni.createFrom().failure(error);
   }
 
-  private static class VertexContextExecutor implements Executor {
+  private static class VertxContextExecutor implements Executor {
 
     private final Context context;
 
-    public VertexContextExecutor(Context context) {
+    public VertxContextExecutor(Context context) {
       this.context = context;
     }
 


### PR DESCRIPTION

Avoid implementing Multi and extend AbstractMulti instead …

Creates the multi instances in the constructor and delegate the subscription to it.
Note that we must handle the subscription interception.

In addition:

* fixed Multi creation interception in the FailedMutinyMappedReactiveResultSet.
* fixed typo in Vert.x (no e)