### PR TITLE
JAVA-2735: Exclude generated classes from the JaCoCo report (fixes #39)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,16 +254,43 @@ limitations under the License.]]></inlineHeader>
         </configuration>
         <executions>
           <execution>
+            <id>prepare-agent-ut</id>
             <goals>
               <goal>prepare-agent</goal>
             </goals>
+            <configuration>
+              <destFile>${project.build.directory}/jacoco-ut.exec</destFile>
+            </configuration>
           </execution>
           <execution>
-            <id>report</id>
-            <phase>prepare-package</phase>
+            <id>prepare-agent-it</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <destFile>${project.build.directory}/jacoco-it.exec</destFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>report-ut</id>
             <goals>
               <goal>report</goal>
             </goals>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco-ut.exec</dataFile>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>report-it</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco-it.exec</dataFile>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,7 @@ limitations under the License.]]></inlineHeader>
         <configuration>
           <excludes>
             <exclude>**/*$$accessor.class</exclude>
+            <exclude>**/*__MapperGenerated*.class</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,11 @@ limitations under the License.]]></inlineHeader>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/*$$accessor.class</exclude>
+          </excludes>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
fixes #39

## Motivation

Some classes are generated and affect the JaCoCo reports.

## Modifications

* Exclude the classes of type `$$accessor.class` generated by the extension annotation processor of Quarkus from the JaCoCo report
* Exclude the mapper generated classes whose name ends with `__MapperGenerated`

## Result

The JaCoCo report is no more affected by the generated classes.

**NB:** The test classes like `CassandraEndpoint` and `CassandraNameConverterEndpoint` have been removed from the project
