### PR TITLE
Make Tinkerpop truly optional (fixes #146)

### DIFF
--- a/bom-runtime/pom.xml
+++ b/bom-runtime/pom.xml
@@ -63,21 +63,18 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <!-- Driver Optional dependencies -->
+      <!-- Driver optional dependencies -->
       <dependency>
         <groupId>org.lz4</groupId>
         <artifactId>lz4-java</artifactId>
         <version>1.6.0</version>
         <optional>true</optional>
       </dependency>
-      <!--
-      Tinkerpop became optional in driver 4.10, but the Quarkus extension cannot work without it for
-      now, see https://datastax-oss.atlassian.net/browse/JAVA-2917
-      -->
       <dependency>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>gremlin-core</artifactId>
         <version>3.4.9</version>
+        <optional>true</optional>
         <exclusions>
           <exclusion>
             <groupId>org.yaml</groupId>
@@ -101,6 +98,7 @@
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkergraph-gremlin</artifactId>
         <version>3.4.9</version>
+        <optional>true</optional>
       </dependency>
       <!-- Cassandra Quarkus Extension (Runtime & Test Framework) -->
       <dependency>

--- a/deployment/src/main/java/com/datastax/oss/quarkus/deployment/internal/CassandraClientProcessor.java
+++ b/deployment/src/main/java/com/datastax/oss/quarkus/deployment/internal/CassandraClientProcessor.java
@@ -53,9 +53,6 @@ import com.datastax.oss.quarkus.deployment.api.CassandraClientBuildTimeConfig;
 import com.datastax.oss.quarkus.runtime.internal.quarkus.CassandraClientProducer;
 import com.datastax.oss.quarkus.runtime.internal.quarkus.CassandraClientRecorder;
 import com.datastax.oss.quarkus.runtime.internal.quarkus.CassandraClientStarter;
-import com.esri.core.geometry.ogc.OGCGeometry;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
@@ -77,10 +74,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0;
 import org.jboss.jandex.DotName;
-import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,19 +90,30 @@ class CassandraClientProcessor {
   }
 
   @BuildStep
-  List<ReflectiveClassBuildItem> registerDriverUsedClassesForReflection() {
+  List<ReflectiveClassBuildItem> registerGraphForReflection() {
     return Arrays.asList(
-        new ReflectiveClassBuildItem(true, true, OGCGeometry.class.getName()),
-        new ReflectiveClassBuildItem(true, true, GraphTraversal.class.getName()),
-        new ReflectiveClassBuildItem(true, true, TinkerIoRegistryV3d0.class.getName()),
-        new ReflectiveClassBuildItem(true, true, JsonParser.class.getName()),
-        new ReflectiveClassBuildItem(true, true, ObjectMapper.class.getName()));
+        new ReflectiveClassBuildItem(
+            true, true, "org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal"),
+        new ReflectiveClassBuildItem(
+            true, true, "org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0"));
+  }
+
+  @BuildStep
+  ReflectiveClassBuildItem registerGeometryForReflection() {
+    return new ReflectiveClassBuildItem(true, true, "com.esri.core.geometry.ogc.OGCGeometry");
+  }
+
+  @BuildStep
+  List<ReflectiveClassBuildItem> registerJsonForReflection() {
+    return Arrays.asList(
+        new ReflectiveClassBuildItem(true, true, "com.fasterxml.jackson.core.JsonParser"),
+        new ReflectiveClassBuildItem(true, true, "com.fasterxml.jackson.databind.ObjectMapper"));
   }
 
   @BuildStep
   List<ReflectiveClassBuildItem> registerReactiveForReflection() {
     return Collections.singletonList(
-        new ReflectiveClassBuildItem(true, true, Publisher.class.getName()));
+        new ReflectiveClassBuildItem(true, true, "org.reactivestreams.Publisher"));
   }
 
   @BuildStep

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -64,6 +64,21 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
+      <exclusions>
+        <!-- test that these dependencies can be excluded -->
+        <exclusion>
+          <groupId>com.esri.geometry</groupId>
+          <artifactId>esri-geometry-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     upgrade them in the quickstart module too.
     -->
     <quarkus.version>1.8.0.Final</quarkus.version>
-    <datastax-java-driver.version>4.10.0</datastax-java-driver.version>
+    <datastax-java-driver.version>4.11.0-SNAPSHOT</datastax-java-driver.version>
     <datastax-java-driver.javadoc.version>4.10</datastax-java-driver.javadoc.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -43,18 +43,6 @@
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
     </dependency>
-    <!--
-    Tinkerpop became optional in driver 4.10, but the Quarkus extension cannot work without it for
-    now, see https://datastax-oss.atlassian.net/browse/JAVA-2917
-    -->
-    <dependency>
-      <groupId>org.apache.tinkerpop</groupId>
-      <artifactId>gremlin-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tinkerpop</groupId>
-      <artifactId>tinkergraph-gremlin</artifactId>
-    </dependency>
     <!-- Driver Object Mapper -->
     <dependency>
       <groupId>com.datastax.oss</groupId>
@@ -104,6 +92,16 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tinkerpop</groupId>
+      <artifactId>gremlin-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tinkerpop</groupId>
+      <artifactId>tinkergraph-gremlin</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Requires driver 4.11.0-SNAPSHOT for now.
Requires JAVA-2917.