### PR TITLE
List quarkus-vertx among dependencies of the runtime module (fixes #203)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
         }
         environment {
           JABBA_VERSION = 'openjdk@1.11'
-          GRAALVM_VERSION = 'graalvm-ce-java11@21.1.0'
+          GRAALVM_VERSION = '11.0.13-graalvm-ce-21.3.0'
         }
 
         stages {

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@ This release is built against Quarkus 2.4.0.Final and the Cassandra driver 4.13.
 
 - [improvement] Warn users when Quarkus main event loop is too small (fixes #194)
 - [new feature] Ability to specify container image and startup options in integration tests (fixes #192)
+- [bug] List quarkus-vertx among dependencies of the runtime module (fixes #203)
 
 ### 1.1.1
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 ### 1.1.2 (in progress)
 
-This release is built against Quarkus 2.4.0.Final and the Cassandra driver 4.13.0.
+This release is built against Quarkus 2.7.0.Final and the Cassandra driver 4.13.0.
 
 - [improvement] Warn users when Quarkus main event loop is too small (fixes #194)
 - [new feature] Ability to specify container image and startup options in integration tests (fixes #192)

--- a/integration-tests/application/pom.xml
+++ b/integration-tests/application/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-vertx-web</artifactId>
+      <artifactId>quarkus-reactive-routes</artifactId>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss.quarkus</groupId>

--- a/integration-tests/dse/src/test/java/com/datastax/oss/quarkus/tests/CustomerResourceIT.java
+++ b/integration-tests/dse/src/test/java/com/datastax/oss/quarkus/tests/CustomerResourceIT.java
@@ -20,10 +20,8 @@ import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 
-import com.datastax.oss.quarkus.test.CassandraTestResource;
 import com.datastax.oss.quarkus.tests.entity.Address;
 import com.datastax.oss.quarkus.tests.entity.Customer;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import java.util.UUID;
@@ -31,8 +29,7 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@QuarkusTestResource(CassandraTestResource.class)
-public class CustomerResourceIT {
+public class CustomerResourceIT extends DseTestBase {
 
   private static final Address ADDRESS1 = new Address("Rue Montorgueil", "75002", "Paris");
   private static final Address ADDRESS2 = new Address("Rue Montmartre", "75002", "Paris");

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     Note: when upgrading the Quarkus version or the DataStax Java driver version, make sure that you
     upgrade them in the quickstart module too.
     -->
-    <quarkus.version>2.4.0.Final</quarkus.version>
+    <quarkus.version>2.7.0.Final</quarkus.version>
     <datastax-java-driver.version>4.13.0</datastax-java-driver.version>
     <assertj.version>3.22.0</assertj.version>
     <maven.compiler.target>11</maven.compiler.target>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -27,7 +27,7 @@
   <inceptionYear>2020</inceptionYear>
   <properties>
     <java.version>11</java.version>
-    <quarkus.version>2.4.0.Final</quarkus.version>
+    <quarkus.version>2.7.0.Final</quarkus.version>
     <datastax-java-driver.version>4.13.0</datastax-java-driver.version>
     <assertj.version>3.22.0</assertj.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -84,6 +84,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Also upgrades to Quarkus 2.6.3.

Merge with rebase (not squash).