### PR TITLE
Define Assertj version

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -41,6 +41,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -53,6 +53,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>

--- a/mapper-processor/pom.xml
+++ b/mapper-processor/pom.xml
@@ -42,6 +42,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     -->
     <quarkus.version>2.4.0.Final</quarkus.version>
     <datastax-java-driver.version>4.13.0</datastax-java-driver.version>
+    <assertj.version>3.22.0</assertj.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -29,6 +29,7 @@
     <java.version>11</java.version>
     <quarkus.version>2.4.0.Final</quarkus.version>
     <datastax-java-driver.version>4.13.0</datastax-java-driver.version>
+    <assertj.version>3.22.0</assertj.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -47,6 +48,11 @@
         <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -43,6 +43,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
Assertj version is not enforced by the Quarkus BOM anymore.

Due to some repeated binary compatibility issues, we had to remove it from the BOM.

Any chance you could release a new version with this fix before February 1st? We will need it for the 2.7 Quarkus Platform release.