### PR TITLE
Cleanup dependencies of deployment module

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -75,23 +75,11 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-context-propagation-deployment</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-health-deployment</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-vertx-http-deployment</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx-deployment</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-jsonp-deployment</artifactId>
+      <artifactId>quarkus-smallrye-health-deployment</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
This was inspired by #207 – it seems we can do some more cleanup in the deployment module. I collated the Quarkus dependencies of the deployment module against those of the runtime module, and made sure they coincide 100%.