### PR TITLE
Quarkus update to 2.16.2.Final

### DIFF
--- a/.github/workflows/quarkus-build-native.yaml
+++ b/.github/workflows/quarkus-build-native.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.0'
+          version: '22.3.1'
           java-version: ${{ matrix.java_version }}
           components: 'native-image'
           github-token: ${{ secrets.GB_TOKEN }}

--- a/.github/workflows/quarkus-build-native.yaml
+++ b/.github/workflows/quarkus-build-native.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.2.0'
+          version: '22.3.0'
           java-version: ${{ matrix.java_version }}
           components: 'native-image'
           github-token: ${{ secrets.GB_TOKEN }}

--- a/.github/workflows/quarkus-build.yaml
+++ b/.github/workflows/quarkus-build.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt-hotspot'
+          distribution: 'temurin'
           java-version: ${{ matrix.java_version }}
           cache: 'maven'
       - name: Build & test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
         }
         environment {
           JABBA_VERSION = 'openjdk@1.11'
-          GRAALVM_VERSION = '11.0.13-graalvm-ce-21.3.0'
+          GRAALVM_VERSION = '11.0.17-graalvm-ce-22.3.0'
         }
 
         stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
         }
         environment {
           JABBA_VERSION = 'openjdk@1.11'
-          GRAALVM_VERSION = '11.0.17-graalvm-ce-22.3.0'
+          GRAALVM_VERSION = '11.0.18-graalvm-ce-22.3.1'
         }
 
         stages {

--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ link:http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.datastax.oss%22.quark
 
 == Compatibility
 
-The extension is compatible with Quarkus version 2.15.0.Final and higher.
+The extension is compatible with Quarkus version `2.16.2.Final` and higher.
 
 It requires Java 11 or higher.
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,7 @@
     Note: when upgrading the Quarkus version or the DataStax Java driver version, make sure that you
     upgrade them in the quickstart module too.
     -->
-<<<<<<< HEAD
     <quarkus.version>2.16.2.Final</quarkus.version>
-=======
-    <quarkus.version>2.15.3.Final</quarkus.version>
->>>>>>> 9d897dc (1. Quarkus update to 2.15.3.Final)
     <datastax-java-driver.version>4.15.0</datastax-java-driver.version>
     <assertj.version>3.23.1</assertj.version>
     <maven.compiler.target>11</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,11 @@
     Note: when upgrading the Quarkus version or the DataStax Java driver version, make sure that you
     upgrade them in the quickstart module too.
     -->
+<<<<<<< HEAD
     <quarkus.version>2.16.2.Final</quarkus.version>
+=======
+    <quarkus.version>2.15.3.Final</quarkus.version>
+>>>>>>> 9d897dc (1. Quarkus update to 2.15.3.Final)
     <datastax-java-driver.version>4.15.0</datastax-java-driver.version>
     <assertj.version>3.23.1</assertj.version>
     <maven.compiler.target>11</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     Note: when upgrading the Quarkus version or the DataStax Java driver version, make sure that you
     upgrade them in the quickstart module too.
     -->
-    <quarkus.version>2.15.0.Final</quarkus.version>
+    <quarkus.version>2.16.2.Final</quarkus.version>
     <datastax-java-driver.version>4.15.0</datastax-java-driver.version>
     <assertj.version>3.23.1</assertj.version>
     <maven.compiler.target>11</maven.compiler.target>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -27,11 +27,7 @@
   <inceptionYear>2020</inceptionYear>
   <properties>
     <java.version>11</java.version>
-<<<<<<< HEAD
     <quarkus.version>2.16.2.Final</quarkus.version>
-=======
-    <quarkus.version>2.15.3.Final</quarkus.version>
->>>>>>> 9d897dc (1. Quarkus update to 2.15.3.Final)
     <datastax-java-driver.version>4.15.0</datastax-java-driver.version>
     <assertj.version>3.23.1</assertj.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -27,7 +27,11 @@
   <inceptionYear>2020</inceptionYear>
   <properties>
     <java.version>11</java.version>
+<<<<<<< HEAD
     <quarkus.version>2.16.2.Final</quarkus.version>
+=======
+    <quarkus.version>2.15.3.Final</quarkus.version>
+>>>>>>> 9d897dc (1. Quarkus update to 2.15.3.Final)
     <datastax-java-driver.version>4.15.0</datastax-java-driver.version>
     <assertj.version>3.23.1</assertj.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -27,7 +27,7 @@
   <inceptionYear>2020</inceptionYear>
   <properties>
     <java.version>11</java.version>
-    <quarkus.version>2.15.0.Final</quarkus.version>
+    <quarkus.version>2.16.2.Final</quarkus.version>
     <datastax-java-driver.version>4.15.0</datastax-java-driver.version>
     <assertj.version>3.23.1</assertj.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Quarkus update to [2.16.2.Final](https://quarkus.io/blog).

Updated `JenkinsFile` to include newer GraalVM as it failed with CI:
```
[2022-12-23T17:03:47.877Z] [ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:2.16.2.Final:build (default) on project cassandra-quarkus-integration-tests-main: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[2022-12-23T17:03:47.877Z] [ERROR] 	[error]: Build step io.quarkus.deployment.pkg.steps.NativeImageBuildStep#build threw an exception: java.lang.IllegalStateException: Out of date version of GraalVM detected: GraalVM 22.3.0 Java 11 CE (Java Version 11.0.13+7-jvmci-22.3-b05). Quarkus currently supports 22.3.0. Please upgrade GraalVM to this version.
...
```

Pre-requisites:
- [ ] Availability of the driver image. This will be made available via [this PR](https://github.com/riptano/openstack-jenkins-drivers/pull/97)