### PR TITLE
Upgrade to Quarkus 3.0.0.CR2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ def initializeEnvironment() {
   env.GITHUB_BRANCH_URL = "${GITHUB_PROJECT_URL}/tree/${env.BRANCH_NAME}"
   env.GITHUB_COMMIT_URL = "${GITHUB_PROJECT_URL}/commit/${env.GIT_COMMIT}"
 
-  env.MAVEN_HOME = "${env.HOME}/.mvn/apache-maven-3.6.0"
+  env.MAVEN_HOME = "${env.HOME}/.mvn/apache-maven-3.6.3"
   env.PATH = "${env.MAVEN_HOME}/bin:${env.PATH}"
 
   sh label: 'Display Java and environment information',script: '''#!/bin/bash -le

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ link:http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.datastax.oss%22.quark
 
 The extension is compatible with Quarkus version `2.16.2.Final` and higher.
 
-It requires Java 11 or higher.
+It requires Java 11 or higher. Quarkus 3 requires at least Maven version `3.6.3` or higher to build correctly (see [Quarkus3 notes](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#maven-versions)).
 
 == Useful links
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,3 +1,9 @@
+### 1.2.0-alpha2
+
+This release is built against [Quarkus 3.0.0.CR2](https://github.com/quarkusio/quarkus/releases/tag/3.0.0.CR2) and the Cassanrda driver [4.15.0](https://search.maven.org/artifact/com.datastax.oss/java-driver-core/4.15.0/bundle).
+
+- [improvement] Upgrade to Quarkus 3.0.0.CR2
+
 ### 1.2.0-alpha1
 
 This release is built against Quarkus 3.0.0.Beta1 and the Cassandra driver 4.15.0.

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     Note: when upgrading the Quarkus version or the DataStax Java driver version, make sure that you
     upgrade them in the quickstart module too.
     -->
-    <quarkus.version>3.0.0.Beta1</quarkus.version>
+    <quarkus.version>3.0.0.CR2</quarkus.version>
     <datastax-java-driver.version>4.15.0</datastax-java-driver.version>
     <assertj.version>3.23.1</assertj.version>
     <maven.compiler.target>11</maven.compiler.target>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -27,7 +27,7 @@
   <inceptionYear>2020</inceptionYear>
   <properties>
     <java.version>11</java.version>
-    <quarkus.version>3.0.0.Beta1</quarkus.version>
+    <quarkus.version>3.0.0.CR2</quarkus.version>
     <datastax-java-driver.version>4.15.0</datastax-java-driver.version>
     <assertj.version>3.23.1</assertj.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Upgrade to [Quarkus `3.0.0.CR2`](https://github.com/quarkusio/quarkus/releases/tag/3.0.0.CR2)