### PR TITLE
Upgrade Quarkus framework to 3.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     Note: when upgrading the Quarkus version or the DataStax Java driver version, make sure that you
     upgrade them in the quickstart module too.
     -->
-    <quarkus.version>3.0.0.Final</quarkus.version>
+    <quarkus.version>3.1.0.Final</quarkus.version>
     <datastax-java-driver.version>4.15.0</datastax-java-driver.version>
     <assertj.version>3.23.1</assertj.version>
     <maven.compiler.target>11</maven.compiler.target>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -27,7 +27,7 @@
   <inceptionYear>2020</inceptionYear>
   <properties>
     <java.version>11</java.version>
-    <quarkus.version>3.0.0.Final</quarkus.version>
+    <quarkus.version>3.1.0.Final</quarkus.version>
     <datastax-java-driver.version>4.15.0</datastax-java-driver.version>
     <assertj.version>3.23.1</assertj.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
[Upgrade to Quarkus Framework 3.1.0.Final](https://github.com/quarkusio/quarkus/releases/tag/3.1.0.Final)