### PR TITLE
Minor build fixes after Quarkus upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,8 +86,8 @@ pipeline {
           label "${OS_VERSION}"
         }
         environment {
-          JABBA_VERSION = 'openjdk@1.11'
-          GRAALVM_VERSION = '11.0.18-graalvm-ce-22.3.1'
+          JABBA_VERSION = 'openjdk@1.17'
+          GRAALVM_VERSION = 'graalvm@21.0.7'
         }
 
         stages {

--- a/pom.xml
+++ b/pom.xml
@@ -354,11 +354,6 @@ limitations under the License.]]></inlineHeader>
                 </goals>
                 <configuration>
                   <excludePackageNames>com.datastax.oss.quarkus.*.internal,com.datastax.oss.quarkus.*.internal.*</excludePackageNames>
-                  <links>
-                    <link>https://javadoc.io/doc/com.datastax.oss/java-driver-core/${datastax-java-driver.version}/</link>
-                    <link>http://smallrye.io/smallrye-reactive-utils/apidocs/</link>
-                    <link>https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/</link>
-                  </links>
                   <sourceFileExcludes>
                     <sourceFileExclude>**/*$$accessor.java</sourceFileExclude>
                     <sourceFileExclude>**/*__MapperGenerated.java</sourceFileExclude>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -267,11 +267,6 @@
                   <goal>jar</goal>
                 </goals>
                 <configuration>
-                  <links>
-                    <link>https://docs.datastax.com/en/drivers/java/latest/</link>
-                    <link>http://smallrye.io/smallrye-reactive-utils/apidocs/</link>
-                    <link>https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/</link>
-                  </links>
                   <sourceFileExcludes>
                     <sourceFileExclude>**/*$$accessor.java</sourceFileExclude>
                     <sourceFileExclude>**/*__MapperGenerated.java</sourceFileExclude>


### PR DESCRIPTION
A few minor changes to make the build green after upgrade to Quarkus 3.25.0 (#247)

* Fix javadoc build breakages
* Update to local Java21 GraalVM install