### PR TITLE
Docs: AstraDB connection details in README.adoc

### DIFF
--- a/quickstart/README.adoc
+++ b/quickstart/README.adoc
@@ -408,7 +408,7 @@ Here's an example of the configuration for DataStax Astra:
 quarkus.cassandra.cloud.secure-connect-bundle=/path/to/secure-connect-bundle.zip
 quarkus.cassandra.auth.username=token
 quarkus.cassandra.auth.password=AstraCS:...
-quarkus.cassandra.keyspace=default_keyspace
+quarkus.cassandra.keyspace=k1
 ----
 
 === Advanced Driver Configuration

--- a/quickstart/README.adoc
+++ b/quickstart/README.adoc
@@ -45,7 +45,7 @@ link:https://docs.datastax.com/en/developer/java-driver/latest[DataStax Java dri
 
 This guide will also use the
 link:https://docs.datastax.com/en/developer/java-driver/latest/manual/mapper[DataStax Object Mapper]
-– a powerful Java-to-CQL mapping framework that greatly simplifies your application's data access
+- a powerful Java-to-CQL mapping framework that greatly simplifies your application's data access
 layer code by sparing you the hassle of writing your CQL queries by hand.
 
 The application built in this quickstart guide is quite simple: the user can add elements in a list
@@ -72,7 +72,7 @@ The `pom.xml` is importing all the Quarkus extensions and dependencies you need.
 
 In this example, we will create an application to manage a list of fruits.
 
-First, let's create our data model – represented by the `Fruit` class – as follows:
+First, let's create our data model, represented by the `Fruit` class, as follows:
 
 [source,java]
 ----
@@ -103,7 +103,7 @@ into, and retrieved from, the Cassandra database. Here, the table name will be i
 class name: `fruit`.
 
 Also, the `name` field represents a Cassandra partition key, and so we are annotating it with
-`@PartitionKey` – another annotation from the Object Mapper library.
+`@PartitionKey`, which is another annotation from the Object Mapper library.
 
 IMPORTANT: Entity classes are normally required to have a default no-arg constructor, unless they
 are annotated with `@PropertyStrategy(mutable = false)`, which is the case here.
@@ -392,11 +392,22 @@ quarkus.cassandra.auth.password=s3cr3t
 
 When connecting to link:https://astra.datastax.com[DataStax Astra], instead of providing a contact
 point and a datacenter, you provide the path to your database's Secure Connect Bundle (SCB) zip file.
-You can [download your SCB](https://docs.datastax.com/en/astra-db-serverless/databases/secure-connect-bundle.html) throught the Astra Portal or the Astra DevOps API.
+You can [download your SCB](https://docs.datastax.com/en/astra-db-serverless/databases/secure-connect-bundle.html) through the Astra Portal or the Astra DevOps API.
 
 You must also provide a username and password, since authentication is always required on
 Astra clusters.
-For username, enter the literal string `token`, and for password, provide an [Astra application token](https://docs.datastax.com/en/astra-db-serverless/administration/manage-application-tokens.html) (prefixed by `AstraCS:`).
+The username and password values are sourced from an [Astra application token](https://docs.datastax.com/en/astra-db-serverless/administration/manage-application-tokens.html).
+You have two options:
+
+- Token-only authentication (Recommended):
+
+   - Set `username` to the literal string `token`.
+   - Set `password` to your actual Astra application token (prefixed by `AstraCS:`).
+
+- Client ID and secret authentication:
+
+   - Set `username` to the `clientId` value generated with the token.
+   - Set `password` to the `secret` value generated with the token.
 
 Treat the SCB and application token as you would any sensitive credentials:
 store them securely and use secure references in your application code.

--- a/quickstart/README.adoc
+++ b/quickstart/README.adoc
@@ -391,21 +391,24 @@ quarkus.cassandra.auth.password=s3cr3t
 === Connecting to a DataStax Astra Cloud Database
 
 When connecting to link:https://astra.datastax.com[DataStax Astra], instead of providing a contact
-point and a datacenter, you should provide a so-called _secure connect bundle_, which should point
-to a valid path to an Astra secure connect bundle file. You can download your secure connect bundle
-from the Astra web console.
+point and a datacenter, you provide the path to your database's Secure Connect Bundle (SCB) zip file.
+You can [download your SCB](https://docs.datastax.com/en/astra-db-serverless/databases/secure-connect-bundle.html) throught the Astra Portal or the Astra DevOps API.
 
-You will also need to provide a username and password, since authentication is always required on
+You must also provide a username and password, since authentication is always required on
 Astra clusters.
+For username, enter the literal string `token`, and for password, provide an [Astra application token](https://docs.datastax.com/en/astra-db-serverless/administration/manage-application-tokens.html) (prefixed by `AstraCS:`).
 
-A sample configuration for DataStax Astra should look like this:
+Treat the SCB and application token as you would any sensitive credentials:
+store them securely and use secure references in your application code.
+
+Here's an example of the configuration for DataStax Astra:
 
 [source,properties]
 ----
 quarkus.cassandra.cloud.secure-connect-bundle=/path/to/secure-connect-bundle.zip
-quarkus.cassandra.auth.username=john
-quarkus.cassandra.auth.password=s3cr3t
-quarkus.cassandra.keyspace=k1
+quarkus.cassandra.auth.username=token
+quarkus.cassandra.auth.password=AstraCS:...
+quarkus.cassandra.keyspace=default_keyspace
 ----
 
 === Advanced Driver Configuration


### PR DESCRIPTION
* The README used the phrase "so-called secure connect bundle", which sounded a bit like it's not actually secure 😅 
* ❓ The README provided username and password examples that seemed like they would be more relevant to DSE/C*. Based on how the drivers authenticate with Astra, I believe Astra expects the SCB + application token authentication (`token` + `AstraCS:...`). Please correct me if that is not true for this extension. 🙏🏻 
* Added helpful links to Astra documentation for the SCB and application token.