### PR TITLE
Minor doc update after Quarkus upgrade

### DIFF
--- a/quickstart/README.adoc
+++ b/quickstart/README.adoc
@@ -459,7 +459,7 @@ docker exec -it local-cassandra-instance cqlsh
 
 In the project root directory:
 
-- Run `mvn clean package` and then `java -jar ./target/cassandra-quarkus-quickstart-*-runner.jar` to
+- Run `mvn clean package` and then `java -jar target/quarkus-app/quarkus-run.jar` to
   start the application;
 - Or better yet, run the application in dev mode: `mvn clean quarkus:dev`.
 

--- a/quickstart/README.adoc
+++ b/quickstart/README.adoc
@@ -459,7 +459,7 @@ docker exec -it local-cassandra-instance cqlsh
 
 In the project root directory:
 
-- Run `mvn clean package` and then `java -jar target/quarkus-app/quarkus-run.jar` to
+- Run `mvn clean package` and then `java -jar ./target/quarkus-app/quarkus-run.jar` to
   start the application;
 - Or better yet, run the application in dev mode: `mvn clean quarkus:dev`.
 


### PR DESCRIPTION
After the upgrade the built JAR looks to be in a slightly different path so let's update the quickstart documentation to point to the right spot.  Interestingly this only applies to the Java side; the path for native execution is still the same (specified [here](https://github.com/datastax/cassandra-quarkus/blob/1.3.0/quickstart/README.adoc?plain=1#L819)).